### PR TITLE
Update the player SDK to 2.0.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,5 +53,5 @@ dependencies {
     implementation(platform("androidx.compose:compose-bom:2023.03.00"))
     implementation("androidx.compose.material3:material3")
     implementation("androidx.activity:activity-compose:1.7.2")
-    implementation("com.bambuser:player-sdk:1.3.2")
+    implementation("com.bambuser:player-sdk:2.0.0")
 }


### PR DESCRIPTION
This fix the product reference bug and add productPublicUrl to the product object